### PR TITLE
feat(styleTransform): add styleTransform opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,4 @@ module.exports = function(importName) {
 | `preventFullImport` | `boolean` | no | `false` | Whether or not to throw when an import is encountered which would cause the entire module to be imported. |
 | `skipDefaultConversion` | `boolean` | no | `false` | When set to true, will preserve `import { X }` syntax instead of converting to `import X`. |
 | `style` | `boolean` | no | `false` | When set to true, will add side effect import of transformed path concatenated with `/style`. |
+| `styleTransform` | `function` | no | `false` | Can be optional, a function received transformed path argument, further tuning the style import path. |

--- a/README.md
+++ b/README.md
@@ -135,5 +135,4 @@ module.exports = function(importName) {
 | `transform` | `string` | yes | `undefined` | The library name to use instead of the one specified in the import statement.  ${member} will be replaced with the member, aka Grid/Row/Col/etc.  Alternatively, pass a path to a .js file which exports a function to process the transform (see Advanced Transformations) |
 | `preventFullImport` | `boolean` | no | `false` | Whether or not to throw when an import is encountered which would cause the entire module to be imported. |
 | `skipDefaultConversion` | `boolean` | no | `false` | When set to true, will preserve `import { X }` syntax instead of converting to `import X`. |
-| `style` | `boolean` | no | `false` | When set to true, will add side effect import of transformed path concatenated with `/style`. |
-| `styleTransform` | `function` | no | `undefined` | Can be optional, a function received transformed path argument, further tuning the style import path. |
+| `style` | `boolean` or `function` | no | `false` | When set to true, will add side effect import of transformed path concatenated with `/style`. When set as a function, receive an argument as the transformed path, return the tramsformed style module path |

--- a/README.md
+++ b/README.md
@@ -136,4 +136,4 @@ module.exports = function(importName) {
 | `preventFullImport` | `boolean` | no | `false` | Whether or not to throw when an import is encountered which would cause the entire module to be imported. |
 | `skipDefaultConversion` | `boolean` | no | `false` | When set to true, will preserve `import { X }` syntax instead of converting to `import X`. |
 | `style` | `boolean` | no | `false` | When set to true, will add side effect import of transformed path concatenated with `/style`. |
-| `styleTransform` | `function` | no | `false` | Can be optional, a function received transformed path argument, further tuning the style import path. |
+| `styleTransform` | `function` | no | `undefined` | Can be optional, a function received transformed path argument, further tuning the style import path. |

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,7 +159,7 @@ class PluginTransformImport extends Visitor {
                     transformedNodes.push(copyNode);
 
                     if (style) {
-                        const nodeValue = typeof style === 'function' ? style(value) : `${value}/style`;
+                        const nodeValue: string = typeof style === 'function' ? style(value) : `${value}/style`;
 
                         const styleNode = {
                             ...node,

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,13 +159,11 @@ class PluginTransformImport extends Visitor {
                     transformedNodes.push(copyNode);
 
                     if (style) {
-                        const nodeValue = (typeof style === 'function' ? style(value) : `${value}/style`) as string;
-
                         const styleNode = {
                             ...node,
                             source: {
                                 ...source,
-                                value: nodeValue,
+                                value: typeof style === 'function' ? style(value) : `${value}/style`,
                             },
                             specifiers: [],
                             type: "ImportDeclaration",

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,7 +171,7 @@ class PluginTransformImport extends Visitor {
                         transformedNodes.push(styleNode);
                     }
 
-                    if (styleTransform) {
+                    if (styleTransform && typeof styleTransform === 'function') {
                         const styleNode = {
                             ...node,
                             source: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,8 +45,8 @@ function barf(msg: String) {
 }
 
 
-function transformImportPath(transformOption: any, importName: string) {
-    if (!transformOption) return;
+function transformImportPath(transformOption: any, importName: string): string {
+    if (!transformOption) return '';
 
     const isFunction = typeof transformOption === 'function';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,7 +159,7 @@ class PluginTransformImport extends Visitor {
                     transformedNodes.push(copyNode);
 
                     if (style) {
-                        const nodeValue: string = typeof style === 'function' ? style(value) : `${value}/style`;
+                        const nodeValue = (typeof style === 'function' ? style(value) : `${value}/style`) as string;
 
                         const styleNode = {
                             ...node,

--- a/test/transform-import.test.mjs
+++ b/test/transform-import.test.mjs
@@ -137,7 +137,7 @@ describe('PluginImport', function () {
     import { Row, Grid as MyGrid } from 'react-bootstrap';
     `.trimStart().replace(/^\s+/mg, ''));
   });
-  
+
   it('should import style', function () {
     const opts = {
       "antd": {
@@ -157,6 +157,29 @@ describe('PluginImport', function () {
     assert.equal(output.code, `
       import Button from 'antd/es/Button';
       import 'antd/es/Button/style';
+    `.trimStart().replace(/^\s+/mg, ''));
+  });
+
+  it('should import style with styleTransform', function () {
+
+    const opts = {
+      "antd": {
+        "transform": "antd/es/${member}",
+        "styleTransform": (transformedPath) => `${transformedPath}/style/css.js`
+      },
+    }
+
+    const output = transformSync(`
+      import { Breadcrumb } from 'antd';
+    `, {
+      plugin(m) {
+        return new PluginImport.default(opts).visitProgram(m);
+      },
+    });
+
+    assert.equal(output.code, `
+      import Breadcrumb from 'antd/es/Breadcrumb';
+      import 'antd/es/Breadcrumb/style/css.js';
     `.trimStart().replace(/^\s+/mg, ''));
   });
 });

--- a/test/transform-import.test.mjs
+++ b/test/transform-import.test.mjs
@@ -2,7 +2,6 @@ import { strict as assert } from 'assert';
 import expect from 'expect';
 
 import { transformSync } from '@swc/core';
-
 import PluginImport from '../lib/index.js';
 
 describe('PluginImport', function () {
@@ -138,48 +137,49 @@ describe('PluginImport', function () {
     `.trimStart().replace(/^\s+/mg, ''));
   });
 
-  it('should import style', function () {
-    const opts = {
-      "antd": {
-        "transform": "antd/es/${member}",
-        "style": true
-      },
-    }
+  describe('should import style', function () {
+    it('default transform', function () {
+      const opts = {
+        "antd": {
+          "transform": "antd/es/${member}",
+          "style": true
+        },
+      }
 
-    const output = transformSync(`
-      import { Button } from 'antd';
-    `, {
-      plugin(m) {
-        return new PluginImport.default(opts).visitProgram(m);
-      },
+      const output = transformSync(`
+        import { Button } from 'antd';
+      `, {
+        plugin(m) {
+          return new PluginImport.default(opts).visitProgram(m);
+        },
+      });
+
+      assert.equal(output.code, `
+        import Button from 'antd/es/Button';
+        import 'antd/es/Button/style';
+      `.trimStart().replace(/^\s+/mg, ''));
     });
 
-    assert.equal(output.code, `
-      import Button from 'antd/es/Button';
-      import 'antd/es/Button/style';
-    `.trimStart().replace(/^\s+/mg, ''));
-  });
+    it('customized transform', function () {
+      const opts = {
+        "antd": {
+          "transform": "antd/es/${member}",
+          "style": (transformedPath) => `${transformedPath}/style/css.js`
+        },
+      }
 
-  it('should import style with styleTransform', function () {
+      const output = transformSync(`
+        import { Breadcrumb } from 'antd';
+      `, {
+        plugin(m) {
+          return new PluginImport.default(opts).visitProgram(m);
+        },
+      });
 
-    const opts = {
-      "antd": {
-        "transform": "antd/es/${member}",
-        "styleTransform": (transformedPath) => `${transformedPath}/style/css.js`
-      },
-    }
-
-    const output = transformSync(`
-      import { Breadcrumb } from 'antd';
-    `, {
-      plugin(m) {
-        return new PluginImport.default(opts).visitProgram(m);
-      },
-    });
-
-    assert.equal(output.code, `
-      import Breadcrumb from 'antd/es/Breadcrumb';
-      import 'antd/es/Breadcrumb/style/css.js';
-    `.trimStart().replace(/^\s+/mg, ''));
-  });
+      assert.equal(output.code, `
+        import Breadcrumb from 'antd/es/Breadcrumb';
+        import 'antd/es/Breadcrumb/style/css.js';
+      `.trimStart().replace(/^\s+/mg, ''));
+    })
+  })
 });


### PR DESCRIPTION
There are some cases we need to fine tune the transformed `style` import.

I propose complementing the style opt as a function

`style: (transformedPath: string) => string`

Inspired from [`babel-plugin-import` ](https://github.com/umijs/babel-plugin-import#style)
https://www.npmjs.com/package/babel-plugin-import#style